### PR TITLE
Disable "variable assigned but not used" warnings in StringTest.

### DIFF
--- a/Assets/Scripts/Scenes/StringTest.cs
+++ b/Assets/Scripts/Scenes/StringTest.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿#pragma warning disable 0219 // variable assigned but not used.
+using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
 


### PR DESCRIPTION
The variable is "used" for testing purposes
